### PR TITLE
swith use invoice preprinted logo footer cgv paper

### DIFF
--- a/htdocs/admin/facture.php
+++ b/htdocs/admin/facture.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2008		Raphael Bertrand (Resultic)	<raphael.bertrand@resultic.fr>
  * Copyright (C) 2012-2013  Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2014		Teddy Andreotti				<125155@supinfo.com>
+ * Copyright (C) 2017       Ari Elbaz (elarifr)	        <github@accedinfo.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -697,8 +698,53 @@ print '<td width="80">&nbsp;</td>';
 print "</tr>\n";
 $var=true;
 
+// Elarifr Default invoice use preprint paper (logo & footer)
+// TODO Check entity !
+// TODO Add rights to manage setting by user on generate documents ?
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("FactureUsePreprint");
+$htmltooltip = $langs->trans("FactureUsePreprintInfo");
+print $form->textwithpicto('',$htmltooltip,1,0);
+//TODO move to language file
+$htmltooltip = 'Enable if you use paper with preprinted logo & footer. Disable to print logo & Footer. This can be changed by user';
+print $form->textwithpicto('',$htmltooltip,1,0);
+print '</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('FACTURE_USE_PREPRINT'); //,,$conf->entity
+print '</td></tr>';
+
+// Elarifr Default invoice use preprint paper with cgv
+// TODO Check entity !
+// TODO Add rights to manage setting by user on generate documents ?
+// TODO Add help tooltip for cgv.pdf file if found and where to upload it
+// Upload of cgv direcltly provided here ?
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("FactureUsePreprintCgv");
+$htmltooltip = $langs->trans("FactureUsePreprintCgvInfo");
+//TODO move to language file
+print $form->textwithpicto('',$htmltooltip,1,0);
+$htmltooltip = 'Enable if you use paper with preprinted cgv. Disable to append cgv.pdf if any found in society folder & should manage multilanguage cgv.';
+print $form->textwithpicto('',$htmltooltip,1,0);
+print '</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('FACTURE_USE_PREPRINT_CGV'); //,,$conf->entity
+print '</td></tr>';
+
+
 // Force date validation
+// TODO Check entity !
 $var=! $var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("ForceInvoiceDate").'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('FAC_FORCE_DATE_VALIDATION'); // ,,$conf->entity
+print '</td></tr>';
+/*
 print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
 print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'" />';
 print '<input type="hidden" name="action" value="setforcedate" />';
@@ -710,7 +756,7 @@ print '</td><td align="right">';
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" />';
 print "</td></tr>\n";
 print '</form>';
-
+*/
 $substitutionarray=pdf_getSubstitutionArray($langs, null, null, 2);
 $substitutionarray['__(AnyTranslationKey)__']=$langs->trans("Translation");
 $htmltext = '<i>'.$langs->trans("AvailableVariables").':<br>';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2013      Cédric Salvador       <csalvador@gpcsolutions.fr>
  * Copyright (C) 2014	   Ferran Marcet	 	 <fmarcet@2byte.es>
  * Copyright (C) 2015-2016 Marcos García         <marcosgdf@gmail.com>
+ * Copyright (C) 2017       Ari Elbaz (elarifr)	        <github@accedinfo.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +46,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formother.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formmargin.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/invoice.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
@@ -4471,6 +4473,9 @@ else if ($id > 0 || ! empty($ref))
 		$genallowed = $user->rights->facture->lire;
 		$delallowed = $user->rights->facture->creer;
 
+		//Elarifr we reset print switch values to default as set in admin
+		dolibarr_set_const($db, "FACTURE_USE_PREPRINT_TEMP",$conf->global->FACTURE_USE_PREPRINT,'chaine',0,'',$conf->entity);
+		dolibarr_set_const($db, "FACTURE_USE_PREPRINT_CGV_TEMP",$conf->global->FACTURE_USE_PREPRINT_CGV,'chaine',0,'',$conf->entity);
 		print $formfile->showdocuments('facture', $filename, $filedir, $urlsource, $genallowed, $delallowed, $object->modelpdf, 1, 0, 0, 28, 0, '', '', '', $soc->default_lang);
 		$somethingshown = $formfile->numoffiles;
 

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -7,7 +7,8 @@
  * Copyright (C) 2014		Marcos García		<marcosgdf@gmail.com>
  * Copyright (C) 2015		Bahfir Abbes		<bafbes@gmail.com>
  * Copyright (C) 2016-2017	Ferran Marcet		<fmarcet@2byte.es>
-
+ * Copyright (C) 2017       Ari Elbaz (elarifr)	        <github@accedinfo.com>
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
@@ -641,6 +642,31 @@ class FormFile
 				$out.= '&nbsp;';
 			}
 
+			// Elarifr Facture printing options
+			if (in_array($modulepart,array('facture')))
+            // The optional print switch are implemented only for such elements. 
+            // TEMP values are resetted from facture/card.php to report admin default value
+            // TODO Add & Check users rights to change option
+            // 'propal','order','commande','supplier_proposal''proposal',,'expedition', 'commande_fournisseur', 'expensereport'
+			{
+				//Switch Preprint
+				//TODO Check module context is facture devis commande...
+				$out.='&nbsp;'.$langs->trans("FactureUsePreprintSmall");
+				$htmltooltip = $langs->trans("FactureUsePreprintInfo");
+				$out.=$form->textwithpicto('',$htmltooltip,1,0);
+				$out.= ajax_constantonoff('FACTURE_USE_PREPRINT_TEMP'); //,,$conf->entity
+
+				//Switch Preprint CGV
+				//TODO Check module context is facture devis commande...
+				$out.=$langs->trans("FactureUsePreprintCgvSmall");
+				$htmltooltip = $langs->trans("FactureUsePreprintCgvInfo");
+				$out.=$form->textwithpicto('',$htmltooltip,1,0);
+				$out.= ajax_constantonoff('FACTURE_USE_PREPRINT_CGV_TEMP'); //,,$conf->entity
+				$out.= '&nbsp;';
+			}
+
+            // Elarifr TODO Expand for other doc to build using preprinted papers propal, orders.....
+
 			// Button
 			$genbutton = '<input class="button buttongen" id="'.$forname.'_generatebutton" name="'.$forname.'_generatebutton"';
 			$genbutton.= ' type="submit" value="'.$buttonlabel.'"';
@@ -664,6 +690,7 @@ class FormFile
 				}
 			}
 			$out.= '</tr>';
+
 
 			// Execute hooks
 			$parameters=array('socid'=>(isset($GLOBALS['socid'])?$GLOBALS['socid']:''),'id'=>(isset($GLOBALS['id'])?$GLOBALS['id']:''),'modulepart'=>$modulepart);


### PR DESCRIPTION
add option switch in admin to set default preprint paper and user can
switch before generating final invoice
settings can be used for any print model to offer blank or preprinted paper to end user without need to maintain two printing version module
if agreed to be added in the core i will update also order & propal admin & crabe / azur / einstein models